### PR TITLE
fix phpstan / php-stan (8.2) Property Commande::$status (int) in isse…

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -121,7 +121,7 @@ class Commande extends CommonOrder
 	 * Status of the order
 	 * @var int
 	 */
-	public $status;
+	public $status = 0;
 
 	/**
 	 * @var int Status Billed or not


### PR DESCRIPTION
…t() is not nullable.



